### PR TITLE
fix: enable dynamic import for mediapipe CDN module

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,9 @@ module.exports = {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'), // v3 will serve from memory; this is for prod build
     clean: true,
+    environment: {
+      dynamicImport: true,
+    },
   },
 
   devtool: 'source-map',


### PR DESCRIPTION
## Summary
- allow webpack to output dynamic `import()` calls so Mediapipe module from CDN can load

## Testing
- `npm run build`
- `npm run lint` *(fails: hint not found)*
- `npm run stylelint`
- `npm run eslint` *(fails: TypeError: Cannot read properties of null (reading 'value'))*


------
https://chatgpt.com/codex/tasks/task_e_68afac3c0c64832a84e696a6cd9c803a