### PR TITLE
Use Phaser video background during Rock Mode

### DIFF
--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -14,7 +14,6 @@ import {
   DIE_SOUND,
   START_BUTTON,
 } from './shared.js';
-
 import { loadTrack, play, getTime, resumeOnGesture } from '../audio.js';
 
 const FLAP = 'flap';
@@ -36,69 +35,91 @@ const PLAYING_STATE = 'playing-state';
 const GAME_OVER_STATE = 'gameover-state';
 const DIGIT_WIDTH = 24;
 const BEST_SCORE_KEY = 'best-score';
-// --- Social links (edit to yours) ---
+
+// Social / UI
 const IG_PROFILE_URL = 'https://www.instagram.com/christianaiband/';
 const LINKTREE_URL   = 'https://linktr.ee/lostboyfound';
 const SHARE_TITLE    = 'How about...Flappy Bird but make it Christian';
 const SHARE_TEXT     = 'Try to beat my score in this Christian music Flappy clone 🎶';
-const SHARE_URL      = 'https://christianaiband.com/game.html'; // or your dev URL
+const SHARE_URL      = 'https://christianaiband.com/game.html';
 const NOW_PLAYING_FALLBACK = 'Now Playing: Psalm 32';
 const SONG_URL = 'https://youtu.be/nhCYQhJPPWo?si=DomJK051-IboPCYg';
-const SOUND_HINT_MS = 2200; // how long to show the “check volume” hint
+const SOUND_HINT_MS = 2200;
 
-
-
-
-
-// timeline spawn config
+// Timeline
 const LOOKAHEAD = 1.6;
 
-// webcam bubble
+// Camera bubble
 const CAMERA_BUBBLE_SIZE = 75;
+
+// Rock Mode / snapshots
+const SNAPSHOT_POINTS = 1000;
+const MAX_SNAPS_PER_CHORUS = 3;
+const SNAPSHOT_COOLDOWN_MS = 800;
+const DEFAULT_PRECHORUS_LEAD = 3;
+
+// Song completion
+const SONG_COMPLETION_BONUS = 10000;
 
 export default class GameScene extends Phaser.Scene {
   constructor() {
     super(GAME_SCENE_KEY);
+
+    // score/timeline
     this.score = 0;
     this._tl = null;
     this._nextNoteIdx = 0;
     this._nextCoinAt = 0;
     this.notesCollected = 0;
 
-    // Camera state (DOM approach)
+    // Camera state (DOM bubble)
     this.webcamStream = null;
-    this.domVideoEl = null;       // <video> element
+    this.domVideoEl = null;
     this.domVideoSize = CAMERA_BUBBLE_SIZE;
     this.cameraEnabled = false;
     this.camBtn = null;
 
-    // (Phaser video fields kept in case you want to switch back later)
-    this.webcamVideo = null;
+    // Background image sprite & Phaser background video for Rock Mode
+    this.bgSprite = null;
+    this.bgVideo = null; // <— NEW: Phaser.Video used as in-canvas full-screen background
+
+    this.webcamVideo = null; // kept for compatibility if you switch back later
     this.webcamMask = null;
     this.webcamMaskG = null;
 
+    // UI / buttons
     this.startBtn = null;
+    this.restartButton = null;
 
-    // Debug anchor dot
+    // Debug
     this._camDebug = null;
 
-    // Sound Button
+    // Sound toggle
     this.soundBtn = null;
-    this.isMuted = false;   // Phaser’s global mute mirror
-    this._soundHint = null; // transient hint text
+    this.isMuted = false;
+    this._soundHint = null;
 
-    // Rock mode / chorus extras
+    // Progress UI
+    this.progressBg = null;
+    this.progressFill = null;
+    this.timeLabel = null;
+
+    // Rock Mode state
     this.rockModeActive = false;
     this.rockCountdownLabel = null;
-    this.rockCountdownTimer = null;
-    this.faceTracker = null;
-    this.faceLoopHandle = null;
-    this.snapshots = [];
-    this.maxSnapshotsPerChorus = 3;
-    this.snapshotCooldownMs = 800;
-    this.lastSnapshotAt = 0;
+    this.countdownActive = false;
     this.currentChorus = null;
-    this.sunglasses = null;
+
+    // Snapshots
+    this.snapshots = [];
+    this.lastSnapshotAt = 0;
+    this.snapshotStripDiv = null;
+
+    // Song bonus gate
+    this.songBonusAwarded = false;
+
+    // CSS flag
+    this._pulseStyleInjected = false;
   }
 
   create() {
@@ -114,25 +135,13 @@ export default class GameScene extends Phaser.Scene {
     this.createSocialButtons();
     this.createSoundToggle();
 
-    // chorus / rock-mode helpers
-    this.initSnapshotState();
-    this.createRockCountdownUI();
-    this.createSunglassesSticker();
-
-    
-
-
-    // Start button (READY only)
+    // Start / Restart
     const { width, height } = this.scale;
     this.startBtn = this.add.image(width * 0.5, height * 0.7, START_BUTTON)
       .setInteractive()
       .on('pointerdown', (e) => e?.event?.stopPropagation())
-      .on('pointerup', async (e) => {
-        e?.event?.stopPropagation();
-        await this.setPlaying();
-      });
+      .on('pointerup', async (e) => { e?.event?.stopPropagation(); await this.setPlaying(); });
 
-    // Restart button (GAME OVER)
     this.restartButton = this.add.image(width * 0.5, height * 0.8, START_BUTTON)
       .setInteractive()
       .setVisible(false)
@@ -146,7 +155,7 @@ export default class GameScene extends Phaser.Scene {
     this.hitSound = this.sound.add(HIT_SOUND);
     this.dieSound = this.sound.add(DIE_SOUND);
 
-    // Colliders
+    // Collisions
     this.physics.add.existing(this.ground, true);
     this.physics.add.collider(this.player, this.ground, this.setGameOver, null, this);
     this.physics.add.collider(this.player, this.pipes.topPipes, this.setGameOver, this.handleFall, this);
@@ -172,325 +181,240 @@ export default class GameScene extends Phaser.Scene {
 
     // Timeline + audio
     this._tl = this.cache.json.get('timeline') || null;
-    if (this._tl?.audio) {
-      loadTrack(this._tl.audio).catch((e) => console.warn('Audio load failed:', e));
-    }
+    if (this._tl?.audio) loadTrack(this._tl.audio).catch(() => {});
 
-    // Camera toggle UI (starts OFF)
+    // Progress bar
+    this.createProgressUI();
+
+    // Camera toggle (below Start)
     this.createCameraToggle();
 
-    // Prefer timeline title if present; otherwise fallback
-const nowPlayingText = this._tl?.title || NOW_PLAYING_FALLBACK;
-this.createNowPlayingBanner(nowPlayingText);
+    // Now Playing
+    const nowPlayingText = this._tl?.title || NOW_PLAYING_FALLBACK;
+    this.createNowPlayingBanner(nowPlayingText);
 
+    // Snapshots
+    this.initSnapshotState();
 
     this.setReady();
   }
 
+  // ---------- Now Playing ----------
   createNowPlayingBanner(text) {
-  // Text
-  const label = this.add.text(this.scale.width / 2, 10, text, {
-  fontFamily: 'Teko',
-  fontSize: '24px',
-  color: '#4da6ff',  // hyperlink-style color
-})
-  .setOrigin(0.5, 0)
-  .setDepth(3000)
-  .setScrollFactor(0)
-  .setStroke('#000000', 6)
-  .setShadow(0, 2, '#000000', 4, true, true)
-  .setInteractive({ useHandCursor: true }) // <-- clickable
-  .on('pointerdown', (e) => e?.event?.stopPropagation())
-  .on('pointerup', (e) => {
-    e?.event?.stopPropagation();
-    window.open(SONG_URL, '_blank', 'noopener,noreferrer');
-  });
-
-// Hover effect (desktop)
-label.on('pointerover', () => label.setColor('#82c6ff'));
-label.on('pointerout',  () => label.setColor('#4da6ff'));
-
-
-  // Background pill (graphics)
-  const padX = 12;
-  const padY = 3;
-  const bg = this.add.graphics().setDepth(2999).setScrollFactor(0);
-  const drawBg = () => {
-    bg.clear();
-    const w = label.width + padX * 2;
-    const h = label.height + padY * 2;
-    const x = (this.scale.width - w) / 2;
-    const y = 4; // top margin
-    bg.fillStyle(0x000000, 0.35);
-    bg.fillRoundedRect(x, y, w, h, 10);
-  };
-  drawBg();
-
-  // Subtle animation (alpha pulse)
-  this.tweens.add({
-    targets: label,
-    alpha: { from: 0.85, to: 1 },
-    duration: 1200,
-    yoyo: true,
-    repeat: -1,
-    ease: 'Sine.easeInOut',
-  });
-
-  // Keep positioned nicely on resize
-  this.scale.on('resize', () => {
-    label.x = this.scale.width / 2;
-    label.y = 10;
-    drawBg();
-  });
-
-
-
-
-  // Expose so you can update weekly if you want
-  this.nowPlayingLabel = label;
-  this.nowPlayingBg = bg;
-}
-
-updateNowPlaying(text) {
-  if (!this.nowPlayingLabel) return;
-  this.nowPlayingLabel.setText(text);
-  // Redraw background to fit new width
-  if (this.nowPlayingBg) {
-    const padX = 12, padY = 6;
-    const w = this.nowPlayingLabel.width + padX * 2;
-    const h = this.nowPlayingLabel.height + padY * 2;
-    const x = (this.scale.width - w) / 2;
-    const y = 6;
-    this.nowPlayingBg.clear();
-    this.nowPlayingBg.fillStyle(0x000000, 0.35);
-    this.nowPlayingBg.fillRoundedRect(x, y, w, h, 10);
-  }
-}
-
-  
-  createSocialButtons() {
-  const { width, height } = this.scale;
-  const yBase = height * 0.78;
-
-  const mkBtn = (label, x, onClick) => {
-    const t = this.add.text(x, yBase, label, {
-      fontFamily: 'Teko',
-      fontSize: '15px',
-      color: '#ffffff',
-      backgroundColor: 'rgba(37, 78, 214, 1)',
-      padding: { x: 6, y: 3 }
+    const label = this.add.text(this.scale.width / 2, 10, text, {
+      fontFamily: 'Teko', fontSize: '24px', color: '#4da6ff',
     })
-      .setOrigin(0.5)
-      .setDepth(2000)
+      .setOrigin(0.5, 0).setDepth(3000).setScrollFactor(0)
+      .setStroke('#000000', 6).setShadow(0, 2, '#000000', 4, true, true)
       .setInteractive({ useHandCursor: true })
       .on('pointerdown', (e) => e?.event?.stopPropagation())
-      .on('pointerup',   (e) => { e?.event?.stopPropagation(); onClick(); });
+      .on('pointerup', (e) => { e?.event?.stopPropagation(); window.open(SONG_URL, '_blank', 'noopener,noreferrer'); });
 
-    // subtle hover on desktop
-    t.on('pointerover', () => t.setStyle({ backgroundColor: 'rgba(19, 121, 15, 1)' }));
-    t.on('pointerout',  () => t.setStyle({ backgroundColor: 'hsla(337, 97%, 49%, 1.00)' }));
-    return t;
-  };
+    label.on('pointerover', () => label.setColor('#82c6ff'));
+    label.on('pointerout',  () => label.setColor('#4da6ff'));
 
-  const cx = width * 0.55;
-  this.btnIG       = mkBtn('Follow on Instagram', cx - 110, () => this.openExternal(IG_PROFILE_URL));
-  this.btnShare    = mkBtn('Share',               cx,       () => this.shareScore());
-  this.btnLinktree = mkBtn('Our Music',            cx + 100,  () => this.openExternal(LINKTREE_URL));
+    const padX = 12, padY = 3;
+    const bg = this.add.graphics().setDepth(2999).setScrollFactor(0);
+    const drawBg = () => {
+      bg.clear();
+      const w = label.width + padX * 2;
+      const h = label.height + padY * 2;
+      const x = (this.scale.width - w) / 2;
+      const y = 4;
+      bg.fillStyle(0x000000, 0.35).fillRoundedRect(x, y, w, h, 10);
+    };
+    drawBg();
 
-  this.setSocialButtonsVisible(false);
-}
+    this.tweens.add({ targets: label, alpha: { from: 0.85, to: 1 }, duration: 1200, yoyo: true, repeat: -1, ease: 'Sine.easeInOut' });
+    this.scale.on('resize', () => { label.x = this.scale.width / 2; label.y = 10; drawBg(); });
 
-setSocialButtonsVisible(v) {
-  [this.btnIG, this.btnShare, this.btnLinktree].forEach(b => b && b.setVisible(v));
-}
-
-createSoundToggle() {
-  // Top-right corner
-  const x = this.scale.width - 10;
-  const y = 8;
-
-  this.soundBtn = this.add.text(x, y, this.isMuted ? '🔇' : '🔊', {
-    fontFamily: 'Teko',
-    fontSize: '28px',
-    color: '#ffffff',
-  })
-    .setOrigin(1, 0)           // right/top align
-    .setDepth(3001)
-    .setScrollFactor(0)
-    .setStroke('#000000', 6)
-    .setShadow(0, 2, '#000000', 4, true, true)
-    .setInteractive({ useHandCursor: true })
-    .on('pointerdown', (e) => e?.event?.stopPropagation())
-    .on('pointerup', async (e) => {
-      e?.event?.stopPropagation();
-      await this.toggleSound();
-    });
-
-  // Keep in the corner on resize
-  this.scale.on('resize', () => {
-    if (!this.soundBtn) return;
-    this.soundBtn.x = this.scale.width - 10;
-    this.soundBtn.y = 8;
-  });
-}
-
-async toggleSound() {
-  // Always unlock audio on explicit user gesture
-  try { await resumeOnGesture(); } catch {}
-  try { this.sound.unlock(); } catch {}
-
-  this.isMuted = !this.isMuted;
-  this.sound.mute = this.isMuted;        // Phaser global mute
-  if (this.soundBtn) this.soundBtn.setText(this.isMuted ? '🔇' : '🔊');
-
-  // If unmuted while game is playing, ensure track is actually started/resumed
-  if (!this.isMuted && this.state === 'playing-state' && this._tl?.audio) {
-    try { play(); } catch {}
+    this.nowPlayingLabel = label;
+    this.nowPlayingBg = bg;
   }
 
-  // Optional: show a brief hint if still silent (OS mute/volume)
-  if (!this.isMuted) {
-    this.showSoundHint('If you still can’t hear audio,\nflip your mute switch or raise volume.');
+  updateNowPlaying(text) {
+    if (!this.nowPlayingLabel) return;
+    this.nowPlayingLabel.setText(text);
+    if (this.nowPlayingBg) {
+      const padX = 12, padY = 6;
+      const w = this.nowPlayingLabel.width + padX * 2;
+      const h = this.nowPlayingLabel.height + padY * 2;
+      const x = (this.scale.width - w) / 2;
+      const y = 6;
+      this.nowPlayingBg.clear().fillStyle(0x000000, 0.35).fillRoundedRect(x, y, w, h, 10);
+    }
   }
-}
 
-showSoundHint(msg) {
-  // One at a time
-  if (this._soundHint) { this._soundHint.destroy(); this._soundHint = null; }
+  // ---------- Socials ----------
+  createSocialButtons() {
+    const { width, height } = this.scale;
+    const yBase = height * 0.78;
 
-  const label = this.add.text(this.scale.width / 2, 64, msg, {
-    fontFamily: 'Teko',
-    fontSize: '18px',
-    color: '#ffffff',
-    align: 'center',
-  })
-    .setOrigin(0.5, 0)
-    .setDepth(3000)
-    .setScrollFactor(0)
-    .setStroke('#000000', 6)
-    .setShadow(0, 2, '#000000', 4, true, true)
-    .setAlpha(0);
+    const mkBtn = (label, x, onClick) => {
+      const t = this.add.text(x, yBase, label, {
+        fontFamily: 'Teko', fontSize: '15px', color: '#ffffff',
+        backgroundColor: 'rgba(37, 78, 214, 1)', padding: { x: 6, y: 3 }
+      })
+        .setOrigin(0.5).setDepth(2000)
+        .setInteractive({ useHandCursor: true })
+        .on('pointerdown', (e) => e?.event?.stopPropagation())
+        .on('pointerup',   (e) => { e?.event?.stopPropagation(); onClick(); });
 
-  this._soundHint = label;
+      t.on('pointerover', () => t.setStyle({ backgroundColor: 'rgba(19, 121, 15, 1)' }));
+      t.on('pointerout',  () => t.setStyle({ backgroundColor: 'hsla(337, 97%, 49%, 1.00)' }));
+      return t;
+    };
 
-  // Fade in, wait, fade out
-  this.tweens.add({
-    targets: label,
-    alpha: { from: 0, to: 1 },
-    duration: 200,
-    onComplete: () => {
-      this.time.delayedCall(SOUND_HINT_MS, () => {
-        this.tweens.add({
-          targets: label,
-          alpha: { from: 1, to: 0 },
-          duration: 250,
+    const cx = width * 0.55;
+    this.btnIG       = mkBtn('Follow on Instagram', cx - 110, () => this.openExternal(IG_PROFILE_URL));
+    this.btnShare    = mkBtn('Share',               cx,       () => this.shareScore());
+    this.btnLinktree = mkBtn('Our Music',           cx + 100, () => this.openExternal(LINKTREE_URL));
+    this.setSocialButtonsVisible(false);
+  }
+  setSocialButtonsVisible(v) { [this.btnIG, this.btnShare, this.btnLinktree].forEach(b => b && b.setVisible(v)); }
+  openExternal(url) { window.open(url, '_blank', 'noopener,noreferrer'); }
+  shareScore() {
+    const data = { title: SHARE_TITLE, text: `${SHARE_TEXT} My score: ${this.score}`, url: SHARE_URL };
+    if (navigator.share) navigator.share(data).catch(() => {});
+    else { navigator.clipboard?.writeText(`${data.text} ${data.url}`).catch(() => {}); this.openExternal(IG_PROFILE_URL); }
+  }
+
+  // ---------- Sound toggle ----------
+  createSoundToggle() {
+    const x = this.scale.width - 10, y = 8;
+    this.soundBtn = this.add.text(x, y, this.isMuted ? '🔇' : '🔊', {
+      fontFamily: 'Teko', fontSize: '28px', color: '#ffffff',
+    })
+      .setOrigin(1, 0).setDepth(3001).setScrollFactor(0)
+      .setStroke('#000000', 6).setShadow(0, 2, '#000000', 4, true, true)
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', (e) => e?.event?.stopPropagation())
+      .on('pointerup', async (e) => { e?.event?.stopPropagation(); await this.toggleSound(); });
+
+    this.scale.on('resize', () => { if (this.soundBtn) { this.soundBtn.x = this.scale.width - 10; this.soundBtn.y = 8; }});
+  }
+  async toggleSound() {
+    try { await resumeOnGesture(); } catch {}
+    try { this.sound.unlock(); } catch {}
+    this.isMuted = !this.isMuted;
+    this.sound.mute = this.isMuted;
+    if (this.soundBtn) this.soundBtn.setText(this.isMuted ? '🔇' : '🔊');
+    if (!this.isMuted && this.state === PLAYING_STATE && this._tl?.audio) { try { play(); } catch {} }
+    if (!this.isMuted) this.showSoundHint('If you still can’t hear audio,\nflip your mute switch or raise volume.');
+  }
+  showSoundHint(msg) {
+    if (this._soundHint) { this._soundHint.destroy(); this._soundHint = null; }
+    const label = this.add.text(this.scale.width / 2, 64, msg, {
+      fontFamily: 'Teko', fontSize: '18px', color: '#ffffff', align: 'center',
+    })
+      .setOrigin(0.5, 0).setDepth(3000).setScrollFactor(0)
+      .setStroke('#000000', 6).setShadow(0, 2, '#000000', 4, true, true)
+      .setAlpha(0);
+    this._soundHint = label;
+
+    this.tweens.add({
+      targets: label, alpha: { from: 0, to: 1 }, duration: 200,
+      onComplete: () => { this.time.delayedCall(SOUND_HINT_MS, () => {
+        this.tweens.add({ targets: label, alpha: { from: 1, to: 0 }, duration: 250,
           onComplete: () => { label.destroy(); if (this._soundHint === label) this._soundHint = null; }
         });
-      });
-    }
-  });
-
-  // Recenter on resize
-  this.scale.on('resize', () => {
-    if (!this._soundHint) return;
-    this._soundHint.x = this.scale.width / 2;
-  });
-}
-
-
-openExternal(url) {
-  // open in a new tab safely
-  window.open(url, '_blank', 'noopener,noreferrer');
-}
-
-shareScore() {
-  const scoreMsg = `My score: ${this.score}`;
-  const data = {
-    title: SHARE_TITLE,
-    text: `${SHARE_TEXT} ${scoreMsg}`,
-    url: SHARE_URL
-  };
-
-  if (navigator.share) {
-    navigator.share(data).catch(() => {});
-  } else {
-    // Fallback: copy to clipboard + open Instagram profile (or Linktree)
-    navigator.clipboard?.writeText(`${data.text} ${data.url}`).catch(() => {});
-    this.openExternal(IG_PROFILE_URL);
+      });}
+    });
+    this.scale.on('resize', () => { if (this._soundHint) this._soundHint.x = this.scale.width / 2; });
   }
-}
 
-  
+  // ---------- Progress UI ----------
+  createProgressUI() {
+    const w = this.scale.width * 0.7, h = 8;
+    const x = (this.scale.width - w) / 2, y = 40;
+    this.progressBg = this.add.graphics().setDepth(2500).setScrollFactor(0);
+    this.progressBg.fillStyle(0x000000, 0.35).fillRoundedRect(x, y, w, h, 4);
+    this.progressFill = this.add.graphics().setDepth(2501).setScrollFactor(0);
+    this.progressFill.fillStyle(0xffd200, 0.9).fillRoundedRect(x, y, 0.0001, h, 4);
+    this.timeLabel = this.add.text(this.scale.width / 2, y + h + 6, '0:00 / 0:00', {
+      fontFamily: 'Teko', fontSize: '16px', color: '#ffffff',
+    })
+      .setOrigin(0.5, 0).setDepth(2502).setScrollFactor(0)
+      .setStroke('#000000', 5).setShadow(0, 2, '#000000', 4, true, true);
+
+    this.scale.on('resize', () => {
+      this.progressBg.clear(); this.progressFill.clear();
+      const w2 = this.scale.width * 0.7, x2 = (this.scale.width - w2) / 2, y2 = 40;
+      this.progressBg.fillStyle(0x000000, 0.35).fillRoundedRect(x2, y2, w2, h, 4);
+      this.timeLabel.x = this.scale.width / 2; this.timeLabel.y = y2 + h + 6;
+    });
+  }
+  updateProgressUI() {
+    if (!this._tl?.duration || !this.progressBg || !this.progressFill) return;
+    const total = this._tl.duration;
+    const now = Phaser.Math.Clamp(getTime(), 0, total);
+    const pct = total > 0 ? now / total : 0;
+
+    const w = this.scale.width * 0.7, h = 8;
+    const x = (this.scale.width - w) / 2, y = 40;
+
+    this.progressFill.clear();
+    this.progressFill.fillStyle(0xffd200, 0.95).fillRoundedRect(x, y, Math.max(1, w * pct), h, 4);
+
+    const fmt = (s) => `${Math.floor(s/60)}:${Math.floor(s%60).toString().padStart(2,'0')}`;
+    this.timeLabel.setText(`${fmt(now)} / ${fmt(total)}`);
+  }
+
+  // ---------- Update loop ----------
   update() {
-    // core loop
     this.animate();
     this.handleInputs();
-
-    const now = getTime();
-    this.maybeStartPreChorusCountdown(now);
-    if (this.rockModeActive && this.currentChorus && now >= this.currentChorus.end) {
-      this.exitRockMode();
-    }
-    if (this.rockModeActive) {
-      this.maybeTakeSnapshot(performance.now());
-    }
 
     if (this.state === PLAYING_STATE) {
       this.moveCollectibles();
       this.cleanupCollectibles();
       this.updateTimelineSpawns();
+      this.updateProgressUI();
 
-      if (this._tl?.duration && now >= this._tl.duration) {
+      if (this._tl?.duration && getTime() >= this._tl.duration) {
+        if (!this.songBonusAwarded) { this.songBonusAwarded = true; this.addScore(SONG_COMPLETION_BONUS); this.animateScoreGold(); }
         this.setGameOver();
         this.setSocialButtonsVisible(true);
-
       }
+
+      this.maybeStartPreChorusCountdown(getTime());
+      if (this.rockModeActive && this.currentChorus && getTime() >= this.currentChorus.end) this.exitRockMode();
+      if (this.rockModeActive) this.maybeTakeSnapshot(performance.now());
     }
 
-    // --- DOM camera bubble follow ---
-    if (this.domVideoEl && this.player) {
+    // Keep DOM bubble on the bird when NOT in Rock Mode
+    if (this.domVideoEl && this.player && !this.rockModeActive) {
       const canvas = this.game.canvas;
       const rect = canvas.getBoundingClientRect();
-
-      // scale from game coords -> CSS pixels
       const sx = rect.width / this.scale.gameSize.width;
       const sy = rect.height / this.scale.gameSize.height;
-
       const screenX = rect.left + this.player.x * sx;
-      const screenY = rect.top + this.player.y * sy;
-
-
-      this.domVideoEl.style.left = `${screenX}px`;
-      this.domVideoEl.style.top = `${screenY}px`;
+      const screenY = rect.top  + this.player.y * sy;
+      Object.assign(this.domVideoEl.style, {
+        left: `${screenX}px`, top: `${screenY}px`,
+        width: `${this.domVideoSize}px`, height: `${this.domVideoSize}px`,
+        borderRadius: '50%', border: '5px solid white',
+        boxShadow: '0 0 8px rgba(255,255,255,0.85)', zIndex: '9999', transform: 'translate(-50%, -50%)',
+      });
     }
 
-    // Move the debug dot EVERY frame
-    if (this._camDebug && this.player) {
-      this._camDebug.x = this.player.x;
-      this._camDebug.y = this.player.y - 22;
-      this._camDebug.setDepth(1000);
-    }
+    // Debug dot follow (optional)
+    if (this._camDebug && this.player) { this._camDebug.x = this.player.x; this._camDebug.y = this.player.y - 22; this._camDebug.setDepth(1000); }
   }
 
-  // ---------------- gameplay loop ----------------
+  // ---------- Core game loop ----------
   animate() {
     switch (this.state) {
       case READY_STATE: this.moveGround(); break;
-      case PLAYING_STATE:
-        this.fall();
-        this.movePipes(); this.loopPipes(); this.moveGround();
-        break;
+      case PLAYING_STATE: this.fall(); this.movePipes(); this.loopPipes(); this.moveGround(); break;
       case GAME_OVER_STATE: this.fall(); break;
       default: break;
     }
   }
-
   handleInputs() {
-    // Only Space starts in READY
     if (this.state === READY_STATE) {
-      if (this.cursors.space.isDown) { this.setPlaying(); }
+      if (this.cursors.space.isDown) this.setPlaying();
     } else if (this.state === PLAYING_STATE) {
-      // Flap on tap/space while playing
       if (this.cursors.space.isDown || this.input.activePointer.primaryDown) {
         if (!this.isPlayerFlapping) { this.isPlayerFlapping = true; this.flap(); }
       }
@@ -499,16 +423,19 @@ shareScore() {
       if (this.cursors.space.isDown && this.isAllowedToRestart) this.restart();
     }
   }
-
   isReleased() { return this.cursors.space.isUp && !this.input.activePointer.primaryDown; }
 
+  // ---------- States ----------
   setReady() {
     this.swooshSound.play();
     this.gameoverMessage.visible = false;
     this.bestScoreText.visible = false;
     this.restartButton.visible = false;
-    if (this.btnIG) this.setSocialButtonsVisible(false);
-    
+    this.setSocialButtonsVisible(false);
+
+    // Ensure background image is visible when entering READY
+    if (this.bgSprite) this.bgSprite.setVisible(true);
+    if (this.bgVideo) { this.bgVideo.destroy(); this.bgVideo = null; }
 
     this.player.body.allowGravity = false;
     this.player.anims.play(FLAP, true);
@@ -518,116 +445,85 @@ shareScore() {
 
     if (this.startBtn) this.startBtn.setVisible(true);
     if (this.camBtn) this.camBtn.setVisible(true);
+    this.songBonusAwarded = false;
   }
 
   async setPlaying() {
     if (this.state === PLAYING_STATE) return;
-
     this.birdFlying.stop();
     this.readyMessage.visible = false;
     this.player.body.allowGravity = true;
     this.state = PLAYING_STATE;
-
     if (this.startBtn) this.startBtn.setVisible(false);
-    // keep camBtn visible if you want mid-run toggling
-
-    try {
-      await resumeOnGesture();
-      if (this._tl?.audio) play(0);
-    } catch (_) {}
+    try { await resumeOnGesture(); if (this._tl?.audio) play(0); } catch (_) {}
   }
 
   setGameOver() {
-    if (this.state !== GAME_OVER_STATE) {
-      this.state = GAME_OVER_STATE;
-      this.gameoverMessage.visible = true;
-      this.bestScoreText.visible = true;
-      this.restartButton.visible = true;
-      this.isAllowedToRestart = false;
-      this.hitSound.play();
-      this.player.anims.stop();
+    if (this.state === GAME_OVER_STATE) return;
+    this.state = GAME_OVER_STATE;
+    this.gameoverMessage.visible = true;
+    this.bestScoreText.visible = true;
+    this.restartButton.visible = true;
+    this.isAllowedToRestart = false;
+    this.hitSound.play();
+    this.player.anims.stop();
 
-      // NEW: show socials when game actually ends (collision or song end)
-      this.setSocialButtonsVisible(true);
+    this.setSocialButtonsVisible(true);
+    this.showSnapshotGallery();
 
-      const snapshotBonus = (this.snapshots?.length || 0) * 1000;
-      if (snapshotBonus > 0) {
-        this.addScore(snapshotBonus);
-        this.createGalleryOverlay();
-      } else if (!this.cameraEnabled) {
-        this.add.text(this.scale.width / 2, this.scale.height * 0.55, 'Enable camera during chorus for bonus points 📸', {
-          fontFamily: 'Teko', fontSize: '20px', color: '#ffffff', align: 'center'
-        }).setOrigin(0.5).setDepth(5000);
-      }
+    const currentBest = localStorage.getItem(BEST_SCORE_KEY) || 0;
+    const bestScore = Math.max(currentBest, this.score);
+    localStorage.setItem(BEST_SCORE_KEY, Math.max(this.score, bestScore));
+    this.bestScoreText.setText(`High Score : ${currentBest}`);
 
-      const currentBest = localStorage.getItem(BEST_SCORE_KEY) || 0;
-      const bestScore = Math.max(currentBest, this.score);
-      localStorage.setItem(BEST_SCORE_KEY, Math.max(this.score, bestScore));
-      this.bestScoreText.setText(`High Score : ${currentBest}`);
-
-      this.slideStartButton();
-    }
+    this.slideStartButton();
   }
 
-  flyBirdWhileWaitingForPlayer() {
-    return this.tweens.add({ targets: this.player, y: this.player.y + 5, duration: 300, yoyo: true, repeat: -1 });
-  }
-
+  flyBirdWhileWaitingForPlayer() { return this.tweens.add({ targets: this.player, y: this.player.y + 5, duration: 300, yoyo: true, repeat: -1 }); }
   slideStartButton() {
-    this.tweens.add({
-      targets: this.restartButton, y: this.scale.height * 0.6, duration: 500,
-      onComplete: () => { this.isAllowedToRestart = true; },
-    });
+    this.tweens.add({ targets: this.restartButton, y: this.scale.height * 0.6, duration: 500,
+      onComplete: () => { this.isAllowedToRestart = true; }, });
   }
-
   handleFall() { if (this.state !== GAME_OVER_STATE) this.dieSound.play(); return true; }
 
   restart() {
+    if (this.snapshotStripDiv?.parentNode) { this.snapshotStripDiv.parentNode.removeChild(this.snapshotStripDiv); this.snapshotStripDiv = null; }
     this.clearScore();
     this.coinsGroup.clear(true, true);
     this.notesGroup.clear(true, true);
-    this._nextNoteIdx = 0;
-    this._nextCoinAt = 0;
-    this.notesCollected = 0;
+    this._nextNoteIdx = 0; this._nextCoinAt = 0; this.notesCollected = 0;
     this.setSocialButtonsVisible(false);
+    this.exitRockMode(true);
+    this.initSnapshotState();
 
-    // optional: turn off camera on restart
-    // this.disableWebcamDom();
+    // Ensure bg video is cleaned
+    if (this.bgVideo) { this.bgVideo.destroy(); this.bgVideo = null; }
 
     this.scene.restart();
     this.setReady();
   }
 
   clearScore() { this.score = 0; this.lastRecordedPipe = null; }
-
-  flap() {
-    this.player.setVelocityY(BIRD_VELOCITY);
-    this.player.anims.play(FLAP, true);
-    this.player.angle = -ELEVATION_ANGLE;
-    this.flapSound.play();
+  addScore(n) { this.score += n; this.updateScoreText(); }
+  animateScoreGold() {
+    const kids = this.scoreText.getChildren ? this.scoreText.getChildren() : [];
+    kids.forEach((img) => img.setTint(0xFFD700));
+    this.tweens.add({ targets: kids, scale: { from: 1.0, to: 1.25 }, yoyo: true, duration: 180, ease: 'Quad.easeOut' });
+    this.time.delayedCall(600, () => kids.forEach((img) => img.clearTint()));
   }
 
+  // ---------- Movement / objects ----------
+  flap() { this.player.setVelocityY(BIRD_VELOCITY); this.player.anims.play(FLAP, true); this.player.angle = -ELEVATION_ANGLE; this.flapSound.play(); }
   fall() { if (this.player.angle < FALL_ANGLE) this.player.angle += DECLINE_ANGLE_DELTA; }
-
   moveGround() { this.ground.tilePositionX += GAME_SPEED; }
-
   movePipes() { this.pipes.topPipes.incX(-GAME_SPEED); this.pipes.bottomPipes.incX(-GAME_SPEED); }
-
-  moveCollectibles() {
-    this.coinsGroup.getChildren().forEach((c) => { c.x -= GAME_SPEED; });
-    this.notesGroup.getChildren().forEach((n) => { n.x -= GAME_SPEED; });
-  }
-
-  cleanupCollectibles() {
-    this.coinsGroup.getChildren().forEach((c) => { if (c.getBounds().right < 0) c.destroy(); });
-    this.notesGroup.getChildren().forEach((n) => { if (n.getBounds().right < 0) n.destroy(); });
-  }
+  moveCollectibles() { this.coinsGroup.getChildren().forEach((c) => { c.x -= GAME_SPEED; }); this.notesGroup.getChildren().forEach((n) => { n.x -= GAME_SPEED; }); }
+  cleanupCollectibles() { this.coinsGroup.getChildren().forEach((c) => { if (c.getBounds().right < 0) c.destroy(); }); this.notesGroup.getChildren().forEach((n) => { if (n.getBounds().right < 0) n.destroy(); }); }
 
   createBackground() {
     const { width, height } = this.scale;
-    this.physics.add.staticImage(width * 0.5, height * 0.5, BACKGROUND).setScale(1.7).refreshBody();
+    this.bgSprite = this.physics.add.staticImage(width * 0.5, height * 0.5, BACKGROUND).setScale(1.7).refreshBody();
   }
-
   createPlayer() {
     const { width, height } = this.scale;
     const player = this.physics.add.sprite(width * 0.3, height * 0.5, BIRD);
@@ -637,7 +533,6 @@ shareScore() {
     this.anims.create({ key: FLAP, frames: this.anims.generateFrameNumbers(BIRD, { start: 0, end: 2 }), frameRate: FRAME_RATE, repeat: -1 });
     return player;
   }
-
   createReadyMessage() { const { width, height } = this.scale; return this.add.image(width * 0.5, height * 0.4, READY_MESSAGE); }
   createGameOverMessage() { const { width, height } = this.scale; return this.add.image(width * 0.5, height * 0.3, GAME_OVER_MESSAGE); }
 
@@ -652,35 +547,28 @@ shareScore() {
     score.setOrigin(0, 0);
     return score;
   }
-
   createBestScoreText() {
     const { width, height } = this.scale;
     return this.add.text(width * 0.5, height * 0.4, '', {
       fontFamily: 'Teko', fontSize: '25px', stroke: '#000', strokeThickness: 4,
     }).setOrigin(0.5);
   }
-
   createGround() {
     const { width, height } = this.scale;
     const x = width * 0.5, y = height - GROUND_HEIGHT * 0.3;
     return this.add.tileSprite(x, y, width, GROUND_HEIGHT, GROUND);
   }
-
   createPipePair(x, y) {
-    const top = this.physics.add.image(x, y, PIPE);
-    top.flipY = true; top.body.moves = false; top.setOrigin(0, 0);
+    const top = this.physics.add.image(x, y, PIPE); top.flipY = true; top.body.moves = false; top.setOrigin(0, 0);
     const bottomY = y + PIPE_GAP_HEIGHT + PIPE_HEIGHT;
-    const bottom = this.physics.add.image(x, bottomY, PIPE);
-    bottom.body.moves = false; bottom.setOrigin(0, 0);
+    const bottom = this.physics.add.image(x, bottomY, PIPE); bottom.body.moves = false; bottom.setOrigin(0, 0);
     return [top, bottom];
   }
-
   createPipes() {
     const { width } = this.scale;
     const topPipes = this.physics.add.group();
     const bottomPipes = this.physics.add.group();
     const offsetX = width + PIPE_GAP_LENGTH;
-
     for (let i = 0; i < PIPE_PAIRS; i += 1) {
       const y = Phaser.Math.Between(MIN_PIPE_HEIGHT, 0);
       const deltaX = offsetX + (i * PIPE_GAP_LENGTH);
@@ -689,30 +577,17 @@ shareScore() {
     }
     return { topPipes, bottomPipes };
   }
-
   resetPipesPosition(top, bottom) {
     const x = this.scale.width + PIPE_GAP_LENGTH;
     const y = Phaser.Math.Between(MIN_PIPE_HEIGHT, 0);
     const bottomY = y + PIPE_GAP_HEIGHT + PIPE_HEIGHT;
-    top.y = y; top.x = x;
-    bottom.x = x; bottom.y = bottomY;
+    top.y = y; top.x = x; bottom.x = x; bottom.y = bottomY;
   }
-
-  updateScoreText() {
-    this.scoreText.clear(true, true);
-    this.scoreText = this.createScoreText();
-    this.pointSound.play();
-  }
-
+  updateScoreText() { this.scoreText.clear(true, true); this.scoreText = this.createScoreText(); this.pointSound.play(); }
   updateScore(pipeMiddle, currentPipe) {
     const { right } = this.player.getBounds();
-    if (pipeMiddle < right && this.lastRecordedPipe !== currentPipe) {
-      this.score += 1;
-      this.lastRecordedPipe = currentPipe;
-      this.updateScoreText();
-    }
+    if (pipeMiddle < right && this.lastRecordedPipe !== currentPipe) { this.score += 1; this.lastRecordedPipe = currentPipe; this.updateScoreText(); }
   }
-
   loopPipes() {
     this.pipes.bottomPipes.getChildren().forEach((bottom, index) => {
       const { right, centerX } = bottom.getBounds();
@@ -724,12 +599,11 @@ shareScore() {
     });
   }
 
-  // ---- timeline spawns ----
+  // ---------- Timeline spawns ----------
   updateTimelineSpawns() {
     if (!this._tl) return;
     const now = getTime();
 
-    // notes
     const notes = this._tl.noteMilestones || [];
     while (this._nextNoteIdx < notes.length && notes[this._nextNoteIdx].t <= now + LOOKAHEAD) {
       const evt = notes[this._nextNoteIdx++];
@@ -737,7 +611,6 @@ shareScore() {
       this.spawnNote(this.scale.width + 40, yClamped);
     }
 
-    // coins
     const inChorus = (this._tl.chorusWindows || []).some((w) => now >= w.start && now <= w.end);
     const chorusWin = inChorus ? (this._tl.chorusWindows || []).find((w) => now >= w.start && now <= w.end) : null;
     const rate = inChorus ? (chorusWin?.coinRate || 3.0) : (this._tl.ambientCoins?.rate || 0.7);
@@ -749,19 +622,8 @@ shareScore() {
       this._nextCoinAt = now + baseGap;
     }
   }
-
-  spawnCoin(x, y) {
-    const c = this.coinsGroup.create(x, y, 'coin');
-    if (c?.body) c.body.allowGravity = false;
-    return c;
-  }
-
-  spawnNote(x, y) {
-    const n = this.notesGroup.create(x, y, 'note');
-    if (n?.body) n.body.allowGravity = false;
-    return n;
-  }
-
+  spawnCoin(x, y) { const c = this.coinsGroup.create(x, y, 'coin'); if (c?.body) c.body.allowGravity = false; return c; }
+  spawnNote(x, y) { const n = this.notesGroup.create(x, y, 'note'); if (n?.body) n.body.allowGravity = false; return n; }
   spawnCoinCluster(inChorus, yRange) {
     const rows = inChorus ? 3 : 1;
     for (let i = 0; i < rows; i += 1) {
@@ -770,24 +632,16 @@ shareScore() {
     }
   }
 
-  addScore(n) { this.score += n; this.updateScoreText(); }
-
-  // ---------------- camera UI & controls (DOM) ----------------
-   createCameraToggle() {
-    // Position relative to Start button if available
-    const btnX = this.startBtn ? this.startBtn.x : 10 + 90;
-    const btnY = this.startBtn ? this.startBtn.y + 90 : this.scale.height - 38;
+  // ---------- Camera UI (DOM bubble) ----------
+  createCameraToggle() {
+    const btnX = this.startBtn ? this.startBtn.x : 100;
+    const btnY = this.startBtn ? this.startBtn.y + 50 : this.scale.height - 38;
 
     this.camBtn = this.add.text(btnX, btnY, 'Enable Camera 😆', {
-      fontFamily: 'Teko',
-      fontSize: '20px',
-      color: '#ffffff',
-      backgroundColor: '#e7157eff',
-      padding: { x: 8, y: 4 }
+      fontFamily: 'Teko', fontSize: '20px', color: '#ffffff',
+      backgroundColor: '#e7157eff', padding: { x: 8, y: 4 }
     })
-      .setOrigin(0.5) // center under Start
-      .setScrollFactor(0)
-      .setDepth(1000)
+      .setOrigin(0.5).setScrollFactor(0).setDepth(1000)
       .setInteractive({ useHandCursor: true })
       .on('pointerdown', (e) => e?.event?.stopPropagation())
       .on('pointerup', async (e) => {
@@ -796,41 +650,27 @@ shareScore() {
         else this.disableWebcamDom();
       });
 
-    // keep under Start if resized
     this.scale.on('resize', () => {
       if (this.startBtn && this.camBtn) {
-        this.camBtn.x = this.startBtn.x;
-        this.camBtn.y = this.startBtn.y + 50;
+        this.camBtn.x = this.startBtn.x; this.camBtn.y = this.startBtn.y + 50;
       }
     });
   }
 
-   async enableWebcamDom() {
+  async enableWebcamDom() {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
-        video: { facingMode: 'user', width: { ideal: 300 }, height: { ideal: 300 } },
-        audio: false
+        video: { facingMode: 'user', width: { ideal: 300 }, height: { ideal: 300 } }, audio: false
       });
 
       const video = document.createElement('video');
-      video.playsInline = true;
-      video.muted = true;
-      video.autoplay = true;
-      video.srcObject = stream;
-      video.style.position = 'absolute';
-      video.style.width = `${this.domVideoSize}px`;
-      video.style.height = `${this.domVideoSize}px`;
-      video.style.borderRadius = '50%';
-      video.style.objectFit = 'cover';
-      video.style.pointerEvents = 'none';
-      video.style.zIndex = '9999';
-      video.style.transform = 'translate(-50%, -50%)';
-      video.style.border = '5px solid white';
-      // optional glow for contrast
-      video.style.boxShadow = '0 0 8px rgba(255,255,255,0.85)';
-
+      video.playsInline = true; video.muted = true; video.autoplay = true; video.srcObject = stream;
+      Object.assign(video.style, {
+        position: 'absolute', width: `${this.domVideoSize}px`, height: `${this.domVideoSize}px`,
+        borderRadius: '50%', objectFit: 'cover', pointerEvents: 'none', zIndex: '9999',
+        transform: 'translate(-50%, -50%)', border: '5px solid white', boxShadow: '0 0 8px rgba(255,255,255,0.85)',
+      });
       document.body.appendChild(video);
-
       try { await video.play(); } catch {}
 
       this.domVideoEl = video;
@@ -838,7 +678,7 @@ shareScore() {
       this.cameraEnabled = true;
       this.camBtn?.setText('Disable Camera');
 
-      // Replace the sprite visually
+      // Optional: hide the sprite so bubble "replaces" bird visually
       this.player.setVisible(false);
     } catch (err) {
       console.warn('Webcam error:', err);
@@ -852,200 +692,176 @@ shareScore() {
         this.domVideoEl.srcObject = null;
         this.domVideoEl = null;
       }
-      if (this.webcamStream) {
-        this.webcamStream.getTracks().forEach(t => t.stop());
-        this.webcamStream = null;
-      }
+      if (this.webcamStream) { this.webcamStream.getTracks().forEach(t => t.stop()); this.webcamStream = null; }
     } catch {}
     this.cameraEnabled = false;
     this.camBtn?.setText('Enable Camera');
-
-    // Show the sprite again if you hid it
     this.player.setVisible(true);
   }
 
-  // --------- rock mode helpers ---------
+  // ---------- Rock Mode orchestration ----------
+  initSnapshotState() { this.snapshots = []; this.lastSnapshotAt = 0; this.snapshotCountThisChorus = 0; }
 
-  enterFullscreenCameraBackground() {
-    if (!this.domVideoEl) return;
-    const v = this.domVideoEl;
-    v.style.position = 'absolute';
-    v.style.top = '0';
-    v.style.left = '0';
-    v.style.width = '100vw';
-    v.style.height = '100vh';
-    v.style.objectFit = 'cover';
-    v.style.zIndex = '0';
-    const canvas = this.game.canvas;
-    canvas.style.zIndex = '1';
-  }
+  maybeStartPreChorusCountdown(nowSec) {
+    if (!this._tl?.sections || this.countdownActive || this.rockModeActive) return;
+    const nextChorus = this._tl.sections.find(s => s.type === 'chorus' && s.start > nowSec);
+    if (!nextChorus) return;
 
-  exitFullscreenCameraBackground() {
-    if (!this.domVideoEl) return;
-    const v = this.domVideoEl;
-    v.style.width = `${this.domVideoSize}px`;
-    v.style.height = `${this.domVideoSize}px`;
-    v.style.borderRadius = '50%';
-    v.style.zIndex = '9999';
-    const canvas = this.game.canvas;
-    canvas.style.zIndex = '';
-  }
+    const lead = Math.max(1, this._tl.preChorusLead ?? DEFAULT_PRECHORUS_LEAD);
+    const timeToChorus = nextChorus.start - nowSec;
 
-  initSnapshotState() {
-    this.snapshots = [];
-    this.lastSnapshotAt = 0;
-  }
-
-  maybeStartPreChorusCountdown(now) {
-    if (!this._tl?.sections) return;
-    const lead = this._tl.preChorusLead ?? 3;
-    const upcoming = this._tl.sections.find((s) => s.type === 'chorus' && now < s.start);
-    if (upcoming && upcoming.start - now <= lead && !this.rockCountdownTimer) {
-      this.showRockCountdown(Math.ceil(upcoming.start - now));
-      this.rockCountdownTimer = this.time.addEvent({
-        delay: 1000,
-        repeat: lead - 1,
-        callback: () => {
-          const remaining = Math.ceil(upcoming.start - getTime());
-          if (remaining > 0) this.showRockCountdown(remaining);
-          else {
-            this.hideRockCountdown();
-            this.enterRockMode(upcoming);
-            this.rockCountdownTimer?.remove(false);
-            this.rockCountdownTimer = null;
-          }
-        },
-      });
+    if (timeToChorus <= lead && timeToChorus > 0) {
+      this.countdownActive = true;
+      this.showRockCountdown(Math.ceil(timeToChorus), () => this.enterRockMode(nextChorus));
     }
   }
 
-  enterRockMode(section) {
-    this.rockModeActive = true;
-    this.currentChorus = section;
-    this.enterFullscreenCameraBackground();
-    this.initSnapshotState();
-    this.startFaceLoop();
+  showRockCountdown(seconds, onZero) {
+    if (this.rockCountdownLabel) this.rockCountdownLabel.destroy();
+    const label = this.add.text(this.scale.width / 2, this.scale.height * 0.25, 'GET READY TO ROCK', {
+      fontFamily: 'Teko', fontSize: '40px', color: '#ffffff',
+    }).setOrigin(0.5).setDepth(2600).setStroke('#000000', 8).setShadow(0, 4, '#000000', 8, true, true);
+
+    const num = this.add.text(this.scale.width / 2, this.scale.height * 0.35, `${seconds}`, {
+      fontFamily: 'Teko', fontSize: '64px', color: '#ffd200',
+    }).setOrigin(0.5).setDepth(2600).setStroke('#000000', 8).setShadow(0, 4, '#000000', 8, true, true);
+
+    this.rockCountdownLabel = this.add.container(0, 0, [label, num]);
+
+    const tick = () => {
+      seconds -= 1;
+      if (seconds <= 0) {
+        this.rockCountdownLabel.destroy(); this.rockCountdownLabel = null; this.countdownActive = false;
+        if (onZero) onZero(); return;
+      }
+      num.setText(`${seconds}`);
+      this.tweens.add({ targets: num, scale: { from: 1.2, to: 1.0 }, duration: 250, ease: 'Quad.easeOut' });
+      this.time.delayedCall(1000, tick);
+    };
+
+    this.tweens.add({ targets: label, alpha: { from: 0, to: 1 }, duration: 200 });
+    this.time.delayedCall(1000, tick);
   }
 
-  exitRockMode() {
+  // *** HERE’S THE IMPORTANT CHANGE ***
+  // Use a Phaser Video (in-canvas) for full-screen background during Rock Mode.
+  enterRockMode(chorusSection) {
+    this.rockModeActive = true;
+    this.currentChorus = chorusSection;
+    this.snapshotCountThisChorus = 0;
+    this.injectPulseCssOnce();
+
+    // Hide the static background image
+    if (this.bgSprite) this.bgSprite.setVisible(false);
+
+    if (this.cameraEnabled && this.webcamStream) {
+      // Destroy old bg video if any
+      if (this.bgVideo) { this.bgVideo.destroy(); this.bgVideo = null; }
+
+      // Create Phaser Video and feed the same MediaStream
+      const w = this.scale.width;
+      const h = this.scale.height;
+      const v = this.add.video(w * 0.5, h * 0.5, null).setOrigin(0.5).setDepth(-10); // stay behind everything
+      v.loadMediaStream(this.webcamStream, true); // autoplay
+      v.setDisplaySize(w, h); // full scene
+      this.bgVideo = v;
+
+      // Optional subtle pulse effect by scaling
+      this.tweens.add({
+        targets: v,
+        scale: { from: 1.02, to: 1.0 },
+        duration: 1200,
+        yoyo: true,
+        repeat: -1,
+        ease: 'Sine.easeInOut',
+      });
+
+      // Hide the small DOM bubble while in rock mode
+      if (this.domVideoEl) this.domVideoEl.style.display = 'none';
+    } else {
+      // No camera: small tint flash
+      this.flashBackgroundTint();
+    }
+  }
+
+  exitRockMode(force = false) {
+    if (!this.rockModeActive && !force) return;
     this.rockModeActive = false;
     this.currentChorus = null;
-    this.stopFaceLoop();
-    this.exitFullscreenCameraBackground();
+
+    // Show static background again
+    if (this.bgSprite) this.bgSprite.setVisible(true);
+
+    // Remove Phaser bg video
+    if (this.bgVideo) { this.bgVideo.destroy(); this.bgVideo = null; }
+
+    // Restore DOM bubble if camera is on
+    if (this.cameraEnabled && this.domVideoEl) this.domVideoEl.style.display = 'block';
   }
 
+  flashBackgroundTint() {
+    const g = this.add.rectangle(this.scale.width/2, this.scale.height/2, this.scale.width, this.scale.height, 0xffd200, 0.08).setDepth(1);
+    this.tweens.add({ targets: g, alpha: { from: 0.08, to: 0.0 }, duration: 600, onComplete: () => g.destroy() });
+  }
+
+  injectPulseCssOnce() {
+    if (this._pulseStyleInjected) return;
+    const style = document.createElement('style');
+    style.textContent = `
+      @keyframes rockPulse {
+        0% { filter: contrast(1.05) saturate(1.2) hue-rotate(0deg) brightness(1.0); }
+        50% { filter: contrast(1.15) saturate(1.35) hue-rotate(12deg) brightness(1.1); }
+        100% { filter: contrast(1.05) saturate(1.2) hue-rotate(0deg) brightness(1.0); }
+      }
+      /* kept for DOM-video approach if you flip back later */
+      video.rock-pulse { animation: rockPulse 1.2s ease-in-out infinite; }
+    `;
+    document.head.appendChild(style);
+    this._pulseStyleInjected = true;
+  }
+
+  // ---------- Snapshots ----------
   maybeTakeSnapshot(nowMs) {
-    if (!this.rockModeActive || !this.cameraEnabled || !this.domVideoEl) return;
-    if (this.snapshots.length >= this.maxSnapshotsPerChorus) return;
-    if (nowMs - this.lastSnapshotAt < this.snapshotCooldownMs) return;
+    if (!this.cameraEnabled || !this.domVideoEl || !this.rockModeActive) return;
+    if (this.snapshotCountThisChorus >= MAX_SNAPS_PER_CHORUS) return;
+    if (nowMs - this.lastSnapshotAt < SNAPSHOT_COOLDOWN_MS) return;
 
-    const canvas = document.createElement('canvas');
-    const gameCanvas = this.game.canvas;
-    canvas.width = gameCanvas.width;
-    canvas.height = gameCanvas.height;
-    const ctx = canvas.getContext('2d');
-    if (ctx) {
-      ctx.drawImage(this.domVideoEl, 0, 0, canvas.width, canvas.height);
-      const dataUrl = canvas.toDataURL('image/jpeg', 0.8);
-      this.snapshots.push({ dataUrl, t: nowMs });
-      this.lastSnapshotAt = nowMs;
-    }
-  }
+    const video = this.domVideoEl;
+    const w = 320, h = 320;
+    if (!this._snapCanvas) { this._snapCanvas = document.createElement('canvas'); this._snapCanvas.width = w; this._snapCanvas.height = h; this._snapCtx = this._snapCanvas.getContext('2d'); }
+    const ctx = this._snapCtx;
+    ctx.drawImage(video, 0, 0, w, h);
 
-  async initFaceTrackerIfNeeded() {
-    if (this.faceTracker) return;
     try {
-      const vision = await import('https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/vision_bundle.mjs');
-      const { FaceLandmarker, FilesetResolver } = vision;
-      const filesetResolver = await FilesetResolver.forVisionTasks();
-      this.faceTracker = await FaceLandmarker.createFromOptions(filesetResolver, {
-        baseOptions: { modelAssetPath: undefined },
-        numFaces: 1,
-        runningMode: 'video',
-      });
-    } catch (e) {
-      console.warn('Face tracker init failed', e);
-    }
+      const dataUrl = this._snapCanvas.toDataURL('image/jpeg', 0.85);
+      this.snapshots.push({ dataUrl, t: getTime() });
+      this.snapshotCountThisChorus += 1;
+      this.lastSnapshotAt = nowMs;
+      this.addScore(SNAPSHOT_POINTS);
+      this.animateScoreGold();
+    } catch {}
   }
 
-  startFaceLoop() {
-    if (this.faceLoopHandle || !this.domVideoEl) return;
-    this.initFaceTrackerIfNeeded();
-    const off = document.createElement('canvas');
-    off.width = 256;
-    off.height = 256;
-    const ctx = off.getContext('2d');
-    this.faceLoopHandle = setInterval(async () => {
-      if (!ctx || !this.faceTracker || !this.domVideoEl) return;
-      ctx.drawImage(this.domVideoEl, 0, 0, off.width, off.height);
-      try {
-        const res = await this.faceTracker.detectForVideo(this.domVideoEl, performance.now());
-        if (res?.landmarks?.[0]) {
-          this.positionSunglassesFromLandmarks(res.landmarks[0]);
-        }
-      } catch {}
-    }, 100);
-  }
-
-  stopFaceLoop() {
-    if (this.faceLoopHandle) {
-      clearInterval(this.faceLoopHandle);
-      this.faceLoopHandle = null;
-    }
-    if (this.sunglasses) this.sunglasses.setVisible(false);
-  }
-
-  createRockCountdownUI() {
-    const { width, height } = this.scale;
-    this.rockCountdownLabel = this.add.text(width / 2, height / 2, '', {
-      fontFamily: 'Teko',
-      fontSize: '48px',
-      color: '#ffffff',
-    }).setOrigin(0.5).setDepth(5000).setVisible(false);
-  }
-
-  showRockCountdown(n) {
-    if (this.rockCountdownLabel) {
-      this.rockCountdownLabel.setText(`GET READY TO ROCK ${n}`);
-      this.rockCountdownLabel.setVisible(true);
-    }
-  }
-
-  hideRockCountdown() {
-    this.rockCountdownLabel?.setVisible(false);
-  }
-
-  createSunglassesSticker() {
-    this.sunglasses = this.add.text(0, 0, '😎', {
-      fontSize: '48px',
-    }).setVisible(false).setDepth(4000);
-  }
-
-  positionSunglassesFromLandmarks(lm) {
-    if (!this.sunglasses || !lm) return;
-    const canvas = this.game.canvas;
-    const x = lm[0].x * canvas.width;
-    const y = lm[0].y * canvas.height;
-    this.sunglasses.setPosition(x, y);
-    this.sunglasses.setVisible(true);
-  }
-
-  createGalleryOverlay() {
-    if (!this.snapshots.length) return;
-    const div = document.createElement('div');
-    div.style.position = 'absolute';
-    div.style.bottom = '10px';
-    div.style.left = '50%';
-    div.style.transform = 'translateX(-50%)';
+  showSnapshotGallery() {
+    if (!this.snapshots || this.snapshots.length === 0) return;
+    const strip = document.createElement('div');
+    Object.assign(strip.style, {
+      position: 'fixed', left: '50%', bottom: '16px', transform: 'translateX(-50%)',
+      display: 'flex', gap: '8px', padding: '8px 10px', background: 'rgba(0,0,0,0.35)',
+      borderRadius: '10px', zIndex: '20000',
+    });
     this.snapshots.forEach((s) => {
       const img = document.createElement('img');
       img.src = s.dataUrl;
-      img.style.width = '60px';
-      img.style.height = '60px';
-      img.style.objectFit = 'cover';
-      img.style.margin = '0 4px';
-      div.appendChild(img);
+      Object.assign(img.style, { width: '72px', height: '72px', objectFit: 'cover', borderRadius: '8px', border: '2px solid #ffd200' });
+      strip.appendChild(img);
     });
-    document.body.appendChild(div);
+    const bonus = document.createElement('div');
+    bonus.textContent = `Rock Shots: +${this.snapshots.length}  (Bonus +${this.snapshots.length * SNAPSHOT_POINTS})`;
+    Object.assign(bonus.style, { color: '#ffd200', fontFamily: 'Teko, sans-serif', fontSize: '18px', marginLeft: '10px' });
+    strip.appendChild(bonus);
+    document.body.appendChild(strip);
+    this.snapshotStripDiv = strip;
   }
 }
+


### PR DESCRIPTION
## Summary
- Replace previous Game scene with version that uses a Phaser `Video` playing the webcam stream as the full-screen background during Rock Mode
- Hide the static background when Rock Mode begins and restore it afterwards
- Include progress bar UI that tracks song playtime

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `hint` not found)
- `npm run eslint` (fails: ESLint TypeError)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afafa5c010832aa2902b0ccb6c54a3