### PR TITLE
Preload track to avoid start lag

### DIFF
--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -15,7 +15,7 @@ import {
   START_BUTTON,
 } from './shared.js';
 
-import { loadTrack, play, pause, getTime, getDuration, resumeOnGesture } from '../audio.js';
+import { play, pause, getTime, getDuration, resumeOnGesture } from '../audio.js';
 
 
 
@@ -152,26 +152,10 @@ export default class GameScene extends Phaser.Scene {
     });
 
 // Timeline + audio
-this._tl = this.cache.json.get('timeline') || {};
-
-const declaredDur = Number(this._tl.duration) || 0;   // seconds from JSON (or 0/"auto")
-this._tl.duration = declaredDur;                      // set it NOW so UI uses it
-
-if (this._tl.audio) {
-  loadTrack(this._tl.audio)
-    .then(() => {
-      const audioDur = Math.round(getDuration()) || 0;
-      // If JSON omitted/0/"auto", fall back to decoded audio length
-      if (!this._tl.duration) this._tl.duration = audioDur;
-
-      console.log('[duration] json:', declaredDur,
-                  'audio:', audioDur, 'final:', this._tl.duration);
-
-      // Refresh UI once we know the final value
-      this.updateProgressUI(0, this._tl.duration);
-    })
-    .catch((e) => console.warn('Audio load failed:', e));
-}
+    this._tl = this.cache.json.get('timeline') || {};
+    if (this._tl.audio && !this._tl.duration) {
+      this._tl.duration = Math.round(getDuration()) || 0;
+    }
 
 
 

--- a/src/game/scenes/Preload.js
+++ b/src/game/scenes/Preload.js
@@ -30,6 +30,7 @@ import DieSoundOgg from '../assets/audio/die.ogg';
 // ✅ import timeline JSON and the MP3 so Webpack emits a real URL
 import timelineData from '../assets/data/song-timeline.json';
 import trackUrl from '../assets/audio/track.mp3';
+import { loadTrack, getDuration } from '../audio.js';
 
 import {
   PRELOAD_SCENE_KEY,
@@ -91,10 +92,13 @@ export default class PreloadScene extends Phaser.Scene {
     });
   }
 
-  create() {
+  async create() {
     // ✅ Put the imported JSON into the Phaser cache with the *emitted* MP3 URL
     if (timelineData) {
       const tl = { ...timelineData, audio: trackUrl };
+      await loadTrack(trackUrl);
+      const audioDur = Math.round(getDuration()) || 0;
+      if (!tl.duration) tl.duration = audioDur;
       this.cache.json.add('timeline', tl);
       // Debug (optional): console.log('Timeline audio URL:', tl.audio);
     }


### PR DESCRIPTION
## Summary
- Decode the main music track during the preload scene so audio is ready before gameplay begins.
- Use the cached track duration in the game scene instead of loading the track again.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: hint: not found)*
- `npm run stylelint`
- `npm run eslint` *(fails: TypeError in ESLint rule)*

------
https://chatgpt.com/codex/tasks/task_e_68b107975f84832a9befd21fb238ca5e